### PR TITLE
Added info about ontologies that import qudt in Protege

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ To load QUDT into Protege, choose "Open from URI" from the file menu, and enter 
 
 (The "facade" file that is resolvable on the web (http://qudt.org/2.1/schema/facade/qudt) is already configured to load the OWL schema rather than the SHACL schema, so Protege users will be in the OWL world using this method.)
 
+Ontology libraries
+-----------------------------
+
+Please note that various libraries exhibit different behaviors when importing the QUDT ontology, see this [discussion](https://github.com/qudt/qudt-public-repo/issues/842#issuecomment-1879114604).
+
 Status
 ------
 


### PR DESCRIPTION
A bug with owlapi does not allow to load correctly qudt in Protege if its imported in another ontology. This change documents this and reference the related issues.

This PR allows user to be aware of the issue I posted in [#842](https://github.com/qudt/qudt-public-repo/issues/842)